### PR TITLE
RedHat-8-mysqld.yml new gpg-key

### DIFF
--- a/vars/RedHat-8-mysqld.yml
+++ b/vars/RedHat-8-mysqld.yml
@@ -4,9 +4,9 @@ mysql_default_version: 8.0
 mysql_default_repo: "http://repo.mysql.com/yum/\
       mysql-{{ mysql_version }}-community/\
       el/{{ ansible_distribution_major_version }}/$basearch/"
-mysql_default_gpgkey: https://repo.mysql.com/RPM-GPG-KEY-mysql
+mysql_default_gpgkey: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 mysql_default_repofile: '/etc/yum.repos.d/{{ mysql_daemon }}.repo'
-mysql_fingerprint: 'A4A9 4068 76FC BD3C 4567  70C8 8C71 8D3B 5072 E1F5'
+mysql_fingerprint: '859B E8D7 C586 F538 430B 19C2 467B 942D 3A79 BD29'
 mysql_default_repo_package: https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm
 mysql_default_packages:
   - mysql-community-server


### PR DESCRIPTION
## Description

the packages where signed with a new gpg-key. I only tested against Centos8.

https://stackoverflow.com/questions/71239450/gpg-keys-issue-while-installing-mysql-community-server
https://support.cpanel.net/hc/en-us/articles/4419382481815-MySQL-GPG-keys-expired-preventing-installation-upgrade-of-MySQL-packages-from-the-official-repository-


Fixes # (issue)

## Type of change

https://repo.mysql.com/RPM-GPG-KEY-mysql-2022 new key

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Reviews

Please identify developer to review this change

- [X] @developer

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
